### PR TITLE
travis: replace obsolete go versions with 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
+  - 1.7
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
![](https://media.giphy.com/media/7EamSGumESd0Y/giphy.gif)